### PR TITLE
Add workaround to Readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -3,6 +3,11 @@ Safari Keyword Search
 
 **Not supported in Safari 12/macOS 10.14 Mojave:** Safari Keyword Search is written using the now “legacy” Safari extension API. Starting with Safari 12 these extensions are deprecated, and all new Safari extensions must use the new Safari App Extensions API. This new API does not incude access to the address bar in the same way as the old API, which means that this extension cannot be ported and will be unsupported going forward. Sorry about that.
 
+Two workarounds:
+
+1. Use [Search Alias](https://safari-extensions.apple.com/details/?id=com.damiancarrillo.search-alias-RADJYLEN7P). Requires manually entering all the aliases.
+2. Git clone SafariKeywordSearch. Open Safari and from the Develop menu (enabled via Settings -> Advanced) choose Show Extension Builder. Click "+", then Add Extension. Select the SafariKeywordSearch.safariextension folder. Click run.
+
 ----
 
 Safari Keyword Search is a simple extension for Safari 5.1 and above that can change the default Safari search engine and enables keyword searching from the address bar. This is a simple but powerful feature that gives you access to several search engines using simple keywords. For example, you can search Wikipedia for information on monkeys by typing `w monkeys` in the address bar.

--- a/Readme.md
+++ b/Readme.md
@@ -3,10 +3,7 @@ Safari Keyword Search
 
 **Not supported in Safari 12/macOS 10.14 Mojave:** Safari Keyword Search is written using the now “legacy” Safari extension API. Starting with Safari 12 these extensions are deprecated, and all new Safari extensions must use the new Safari App Extensions API. This new API does not incude access to the address bar in the same way as the old API, which means that this extension cannot be ported and will be unsupported going forward. Sorry about that.
 
-Two workarounds:
-
-1. Use [Search Alias](https://safari-extensions.apple.com/details/?id=com.damiancarrillo.search-alias-RADJYLEN7P). Requires manually entering all the aliases.
-2. Git clone SafariKeywordSearch. Open Safari and from the Develop menu (enabled via Settings -> Advanced) choose Show Extension Builder. Click "+", then Add Extension. Select the SafariKeywordSearch.safariextension folder. Click run.
+As a workaround you can use [Search Alias](https://safari-extensions.apple.com/details/?id=com.damiancarrillo.search-alias-RADJYLEN7P). Requires manually entering all your aliases again.
 
 ----
 


### PR DESCRIPTION
So there's a similar extension called Search Alias in the Safari Extension Gallery which should be around till 31 Dec 2018 (And I wouldn't be surprised if Apple postpones this deadline).

This is the workaround I'm following for now.

Alternatively I found that I could still run SafariKeywordSearch like this:
Git clone SafariKeywordSearch. Open Safari and from the Develop menu (enabled via Settings -> Advanced) choose Show Extension Builder. Click "+", then Add Extension. Select the SafariKeywordSearch.safariextension folder. Click run.

I didn't find a way to persist it though.

Also I couldn't find the location where Safari stores the keyword search settings.

I hope this is helpful to anyone who really relies on these shortcuts many times per day or even hour.

And if you wouldn't mind, it would be nice if you could sign and [submit it](https://developer.apple.com//safari/extensions/submission/), then it should be possible to download till the end of the year.